### PR TITLE
Update SRFI-19 to latest reference implementation, fixing license

### DIFF
--- a/%3a19/srfi-19-test-suite.scm
+++ b/%3a19/srfi-19-test-suite.scm
@@ -93,16 +93,6 @@
        (time=? t3 (time-difference t1 t2))
        (time=? t4 (time-difference t2 t1))))))
 
-(define-s19-test! "Time difference, nanoseconds"
-  (lambda ()
-    (let ((t1 (make-time time-utc 1000 3000))
-          (t2 (make-time time-utc 0 3000))
-          (t3 (make-time time-duration 1000 0))
-          (t4 (make-time time-duration 999999000 -1)))
-      (and
-        (time=? t3 (time-difference t1 t2))
-        (time=? t4 (time-difference t2 t1))))))
-
 
 (define (test-one-utc-tai-edge utc tai-diff tai-last-diff)
   (let* (;; right on the edge they should be the same

--- a/%3a19/srfi-19.scm
+++ b/%3a19/srfi-19.scm
@@ -1,28 +1,25 @@
 ;; SRFI-19: Time Data Types and Procedures.
-;; 
-;; Copyright (C) I/NET, Inc. (2000, 2002, 2003). All Rights Reserved. 
-;; 
-;; This document and translations of it may be copied and furnished to others, 
-;; and derivative works that comment on or otherwise explain it or assist in its 
-;; implementation may be prepared, copied, published and distributed, in whole or 
-;; in part, without restriction of any kind, provided that the above copyright 
-;; notice and this paragraph are included on all such copies and derivative works. 
-;; However, this document itself may not be modified in any way, such as by 
-;; removing the copyright notice or references to the Scheme Request For 
-;; Implementation process or editors, except as needed for the purpose of 
-;; developing SRFIs in which case the procedures for copyrights defined in the SRFI 
-;; process must be followed, or as required to translate it into languages other 
-;; than English. 
-;; 
-;; The limited permissions granted above are perpetual and will not be revoked 
-;; by the authors or their successors or assigns. 
-;; 
-;; This document and the information contained herein is provided on an "AS IS" 
-;; basis and THE AUTHOR AND THE SRFI EDITORS DISCLAIM ALL WARRANTIES, EXPRESS OR 
-;; IMPLIED, INCLUDING BUT NOT LIMITED TO ANY WARRANTY THAT THE USE OF THE 
-;; INFORMATION HEREIN WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED WARRANTIES OF 
-;; MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. 
-
+;;
+;; Copyright (C) I/NET, Inc. (2000, 2002, 2003). All Rights Reserved.
+;;
+;; Permission is hereby granted, free of charge, to any person obtaining
+;; a copy of this software and associated documentation files (the
+;; "Software"), to deal in the Software without restriction, including
+;; without limitation the rights to use, copy, modify, merge, publish,
+;; distribute, sublicense, and/or sell copies of the Software, and to
+;; permit persons to whom the Software is furnished to do so, subject to
+;; the following conditions:
+;;
+;; The above copyright notice and this permission notice shall be
+;; included in all copies or substantial portions of the Software.
+;;
+;; THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+;; EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+;; MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+;; NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+;; LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+;; OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+;; WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ;; -- Bug fixes.
 ;;
@@ -42,9 +39,9 @@
 ;;
 ;; (CURRENT-TIME 'TIME-THREAD) added.
 ;;
-;; TIME-RESOLUTION for TIME-PROCESS added. 
+;; TIME-RESOLUTION for TIME-PROCESS added.
 ;;
-;; TIME comparison procedures (time=?, etc. fixed. 
+;; TIME comparison procedures (time=?, etc. fixed.
 ;;
 ;; Corrected errors in converting between TAI and UTC time.
 ;;
@@ -66,7 +63,7 @@
 ;; fixed julian-day->time-utc and variants.
 ;;
 ;; changes 2003-02-26, based on comments by Martin Gasbichler.
-;; 
+;;
 ;; moronic, overly complicated COPY-TIME procedure changed
 ;; to simple version suggested by Martin Gasbichler.
 ;;
@@ -74,7 +71,7 @@
 ;; and #\tab to #\Tab to (integer->char 9)
 ;;
 ;; changed arity-3 calls to / and - to arity 2 calls (again,
-;; for more general portability). 
+;; for more general portability).
 ;;
 ;; split-real fixed again -- by removing it, and using
 ;; 'fractional part'. Will Fitzgerald 5/16/2003.
@@ -87,7 +84,7 @@
                        (lambda formals body ...)))))
 
 ;;; -- we want receive later on for a couple of small things
-;; 
+;;
 
 ;; :OPTIONAL is nice, too
 
@@ -111,21 +108,21 @@
 (define tm:locale-number-separator ".")
 
 (define tm:locale-abbr-weekday-vector (vector "Sun" "Mon" "Tue" "Wed"
-                                              "Thu" "Fri" "Sat")) 
+                                              "Thu" "Fri" "Sat"))
 (define tm:locale-long-weekday-vector (vector "Sunday" "Monday"
                                               "Tuesday" "Wednesday"
                                               "Thursday" "Friday"
                                               "Saturday"))
-;; note empty string in 0th place. 
+;; note empty string in 0th place.
 (define tm:locale-abbr-month-vector   (vector "" "Jan" "Feb" "Mar"
                                               "Apr" "May" "Jun" "Jul"
                                               "Aug" "Sep" "Oct" "Nov"
-                                              "Dec")) 
+                                              "Dec"))
 (define tm:locale-long-month-vector   (vector "" "January" "February"
                                               "March" "April" "May"
                                               "June" "July" "August"
                                               "September" "October"
-                                              "November" "December")) 
+                                              "November" "December"))
 
 (define tm:locale-pm "PM")
 (define tm:locale-am "AM")
@@ -146,7 +143,7 @@
 
 
 ;;; A Very simple Error system for the time procedures
-;;; 
+;;;
 (define tm:time-error-types
   '(invalid-clock-type
     unsupported-clock-type
@@ -171,7 +168,7 @@
 ;; and update as necessary.
 ;; this procedures reads the file in the abover
 ;; format and creates the leap second table
-;; it also calls the almost standard, but not R5 procedures read-line 
+;; it also calls the almost standard, but not R5 procedures read-line
 ;; & open-input-string
 ;; ie (set! tm:leap-second-table (tm:read-tai-utc-date "tai-utc.dat"))
 
@@ -183,9 +180,9 @@
   (let ( (port (open-input-file filename))
 	 (table '()) )
     (let loop ((line (read-line port)))
-      (if (not (eof-object? line))
+      (if (not (eq? line eof))
 	  (begin
-	    (let* ( (data (read (open-input-string (string-append "(" line ")")))) 
+	    (let* ( (data (read (open-input-string (string-append "(" line ")"))))
 		    (year (car data))
 		    (jd   (cadddr (cdr data)))
 		    (secs (cadddr (cdddr data))) )
@@ -197,7 +194,8 @@
 ;; each entry is ( utc seconds since epoch . # seconds to add for tai )
 ;; note they go higher to lower, and end in 1972.
 (define tm:leap-second-table
- '((1136073600 . 33)
+ '((1230768000 . 34)
+  (1136073600 . 33)
   (915148800 . 32)
   (867715200 . 31)
   (820454400 . 30)
@@ -228,7 +226,7 @@
 
 
 (define (tm:leap-second-delta utc-seconds)
-  (letrec ( (lsd (lambda (table) 
+  (letrec ( (lsd (lambda (table)
 		   (cond
 		    ((>= utc-seconds (caar table))
 		     (cdar table))
@@ -236,7 +234,7 @@
     (if (< utc-seconds  (* (- 1972 1970) 365 tm:sid)) 0
 	(lsd  tm:leap-second-table))))
 
-;; going from tai seconds to utc seconds ... 
+;; going from tai seconds to utc seconds ...
 (define (tm:leap-second-neg-delta tai-seconds)
   (letrec ( (lsd (lambda (table)
 		   (cond ((null? table) 0)
@@ -256,8 +254,9 @@
 
 (define (copy-time time)
   (make-time (time-type time)
-	     (time-nanosecond time)
-	     (time-second time)))
+       (time-nanosecond time)
+	     (time-second time)
+	     ))
 
 
 ;;; current-time
@@ -266,24 +265,23 @@
 ;;; these should be rewritten to be os specific.
 ;;
 ;; -- using gnu gettimeofday() would be useful here -- gets
-;;    second + millisecond 
+;;    second + millisecond
 ;;    let's pretend we do, using mzscheme's current-seconds & current-milliseconds
 ;;    this is supposed to return utc.
-;; 
+;;
 
 (define (tm:get-time-of-day)
   (values (current-seconds)
-	  (let ((r (remainder (current-milliseconds) 1000)))
-            (if (negative? r) (+ 1000 r) r))))
+	  (abs (remainder (current-milliseconds) 1000))))
 
 (define (tm:current-time-utc)
   (receive (seconds ms) (tm:get-time-of-day)
-	   (make-time  time-utc (* ms 1000) seconds )))
+	   (make-time  time-utc (* ms 10000) seconds )))
 
 (define (tm:current-time-tai)
   (receive (seconds ms) (tm:get-time-of-day)
 	   (make-time time-tai
-		      (* ms 1000)
+		      (* ms 10000)
 		      (+ seconds (tm:leap-second-delta seconds))
 		      )))
 
@@ -291,9 +289,9 @@
 
 (define (tm:current-time-ms-time time-type proc)
   (let ((current-ms (proc)))
-    (make-time time-type 
-	       (* (remainder current-ms 1000) 1000)
-	       (quotient current-ms 1000)
+    (make-time time-type
+	       (* (remainder current-ms 1000) 10000)
+	       (quotient current-ms 10000)
 	       )))
 
 ;; -- we define it to be the same as tai.
@@ -304,7 +302,7 @@
 (define (tm:current-time-monotonic)
   (receive (seconds ms) (tm:get-time-of-day)
 	   (make-time time-monotonic
-		      (* ms 1000)
+		      (* ms 10000)
 		      (+ seconds (tm:leap-second-delta seconds))
 		      )))
 
@@ -386,15 +384,19 @@
 ;; -- time arithmetic
 
 (define (tm:time->nanoseconds time)
+  (define (sign1 n)
+    (if (negative? n) -1 1))
   (+ (* (time-second time) tm:nano)
-     (time-nanosecond time)))
+      (time-nanosecond time)))
+
+(define (tm:nanoseconds->time time-type nanoseconds)
+  (make-time time-type
+             (remainder nanoseconds tm:nano)
+             (quotient nanoseconds tm:nano)))
 
 (define (tm:nanoseconds->values nanoseconds)
-  (let ((q (quotient nanoseconds tm:nano))
-        (r (remainder nanoseconds tm:nano)))
-    (if (negative? r)
-      (values (+ tm:nano r) (- q 1))
-      (values r q))))
+  (values (abs (remainder nanoseconds tm:nano))
+          (quotient nanoseconds tm:nano)))
 
 (define (tm:time-difference time1 time2 time3)
   (if (or (not (and (time? time1) (time? time2)))
@@ -405,7 +407,7 @@
       (begin
 	(set-time-second! time3 0)
 	(set-time-nanosecond! time3 0))
-      (receive 
+      (receive
        (nanos secs)
        (tm:nanoseconds->values (- (tm:time->nanoseconds time1)
                                   (tm:time->nanoseconds time2)))
@@ -477,7 +479,7 @@
   (set-time-type! time-out time-utc)
   (set-time-nanosecond! time-out (time-nanosecond time-in))
   (set-time-second!     time-out (- (time-second time-in)
-				    (tm:leap-second-neg-delta 
+				    (tm:leap-second-neg-delta
 				     (time-second time-in))))
   time-out)
 
@@ -495,7 +497,7 @@
   (set-time-type! time-out time-tai)
   (set-time-nanosecond! time-out (time-nanosecond time-in))
   (set-time-second!     time-out (+ (time-second time-in)
-				    (tm:leap-second-delta 
+				    (tm:leap-second-delta
 				     (time-second time-in))))
   time-out)
 
@@ -580,17 +582,12 @@
 (define tm:set-date-year! set-date-year!)
 (define tm:set-date-zone-offset! set-date-zone-offset!)
 
-(define (set-date-nanosecond! date val)
-  (tm:time-error 'set-date-nanosecond! 'dates-are-immutable date))
-
 (define (set-date-second! date val)
   (tm:time-error 'set-date-second! 'dates-are-immutable date))
 
+
 (define (set-date-minute! date val)
   (tm:time-error 'set-date-minute! 'dates-are-immutable date))
-
-(define (set-date-hour! date val)
-  (tm:time-error 'set-date-hour! 'dates-are-immutable date))
 
 (define (set-date-day! date val)
   (tm:time-error 'set-date-day! 'dates-are-immutable date))
@@ -624,7 +621,7 @@
     index)
    (else
     (tm:char-pos char str (+ index 1) len))))
-  
+
 
 (define (tm:fractional-part r)
   (if (integer? r) "0"
@@ -633,7 +630,7 @@
 	  (substring str  (+ ppos 1) (string-length str))))))
 
 
-;; gives the seconds/date/month/year 
+;; gives the seconds/date/month/year
 (define (tm:decode-julian-day-number jdn)
   (let* ((days (truncate jdn))
 	 (a (+ days 32044))
@@ -724,7 +721,7 @@
 	 (offset (date-zone-offset date)) )
     (let ( (jdays (- (tm:encode-julian-day-number day month year)
 		     tm:tai-epoch-in-jd)) )
-      (make-time 
+      (make-time
        time-utc
        nanosecond
        (+ (* (- jdays 1/2) 24 60 60)
@@ -751,7 +748,7 @@
   (tm:leap-year? (date-year date)))
 
 ;; tm:year-day fixed: adding wrong number of days.
-(define  tm:month-assoc '((0 . 0) (1 . 31)  (2 . 59)   (3 . 90)   (4 . 120) 
+(define  tm:month-assoc '((0 . 0) (1 . 31)  (2 . 59)   (3 . 90)   (4 . 120)
 			  (5 . 151) (6 . 181)  (7 . 212)  (8 . 243)
 			  (9 . 273) (10 . 304) (11 . 334)))
 
@@ -766,7 +763,7 @@
 (define (date-year-day date)
   (tm:year-day (date-day date) (date-month date) (date-year date)))
 
-;; from calendar faq 
+;; from calendar faq
 (define (tm:week-day day month year)
   (let* ((a (quotient (- 14 month) 12))
 	 (y (- year a))
@@ -793,7 +790,7 @@
 	       (tm:days-before-first-week  date day-of-week-starting-week))
 	    7))
 
-(define (current-date . tz-offset) 
+(define (current-date . tz-offset)
   (time-utc->date (current-time time-utc)
 		  (:optional tz-offset (tm:local-tz-offset))))
 
@@ -820,12 +817,9 @@
 	 (offset (date-zone-offset date)) )
     (+ (tm:encode-julian-day-number day month year)
        (- 1/2)
-       (+ (/ (+ (* hour 60 60)
-                (* minute 60)
-                second
-                (/ nanosecond tm:nano)
-                (- offset))
-             tm:sid)))))
+       (+ (/ (/ (+ (* hour 60 60)
+		   (* minute 60) second (/ nanosecond tm:nano)) tm:sid)
+	     (- offset))))))
 
 (define (date->modified-julian-day date)
   (- (date->julian-day date)
@@ -846,7 +840,7 @@
 (define (time-tai->julian-day time)
   (if (not (eq? (time-type time) time-tai))
       (tm:time-error 'time-tai->julian-day 'incompatible-time-types  time))
-  (+ (/ (+ (- (time-second time) 
+  (+ (/ (+ (- (time-second time)
 	      (tm:leap-second-delta (time-second time)))
 	   (/ (time-nanosecond time) tm:nano))
 	tm:sid)
@@ -860,7 +854,7 @@
 (define (time-monotonic->julian-day time)
   (if (not (eq? (time-type time) time-monotonic))
       (tm:time-error 'time-monotonic->julian-day 'incompatible-time-types  time))
-  (+ (/ (+ (- (time-second time) 
+  (+ (/ (+ (- (time-second time)
 	      (tm:leap-second-delta (time-second time)))
 	   (/ (time-nanosecond time) tm:nano))
 	tm:sid)
@@ -908,7 +902,7 @@
   (time-utc->modified-julian-day (current-time time-utc)))
 
 ;; returns a string rep. of number N, of minimum LENGTH,
-;; padded with character PAD-WITH. If PAD-WITH if #f, 
+;; padded with character PAD-WITH. If PAD-WITH if #f,
 ;; no padding is done, and it's as if number->string was used.
 ;; if string is longer than LENGTH, it's as if number->string was used.
 
@@ -923,14 +917,14 @@
 				   str-len)) )
 	  (do ((i 0 (+ i 1)))
             ((>= i (string-length str)))
-            (string-set! new-str (+ new-str-offset i) 
+            (string-set! new-str (+ new-str-offset i)
                          (string-ref str i)))
 	  new-str))))
 
 (define (tm:last-n-digits i n)
   (abs (remainder i (expt 10 n))))
 
-(define (tm:locale-abbr-weekday n) 
+(define (tm:locale-abbr-weekday n)
   (vector-ref tm:locale-abbr-weekday-vector n))
 
 (define (tm:locale-long-weekday n)
@@ -965,9 +959,9 @@
 
 
 
-;; do nothing. 
+;; do nothing.
 ;; Your implementation might want to do something...
-;; 
+;;
 (define (tm:locale-print-time-zone date port)
   (values))
 
@@ -991,10 +985,10 @@
 ;; the second is a procedure that takes the date, a padding character
 ;; (which might be #f), and the output port.
 ;;
-(define tm:directives 
+(define tm:directives
   (list
    (cons #\~ (lambda (date pad-with port) (display #\~ port)))
-   
+
    (cons #\a (lambda (date pad-with port)
 	       (display (tm:locale-abbr-weekday (date-week-day date))
 			port)))
@@ -1028,10 +1022,14 @@
 		   (display (tm:padding (date-second date)
 					pad-with 2)
 			    port))
-	       (display tm:locale-number-separator port)
-               (display (tm:fractional-part (/ (date-nanosecond date)
-                                               tm:nano))
-                        port)))
+	       (let* ((ns (tm:fractional-part (/
+					       (date-nanosecond date)
+					       tm:nano 1.0)))
+		      (le (string-length ns)))
+		 (if (> le 2)
+		     (begin
+		       (display tm:locale-number-separator port)
+		       (display (substring ns 2 le) port))))))
    (cons #\h (lambda (date pad-with port)
 	       (display (date->string date "~b") port)))
    (cons #\H (lambda (date pad-with port)
@@ -1115,7 +1113,7 @@
 		   (display (tm:padding (date-week-number date 1)
 					#\0 2) port))))
    (cons #\y (lambda (date pad-with port)
-	       (display (tm:padding (tm:last-n-digits 
+	       (display (tm:padding (tm:last-n-digits
 				     (date-year date) 2)
 				    pad-with
 				    2)
@@ -1156,45 +1154,45 @@
 	      (tm:date-printer date (+ index 1) format-string str-len port))
 
 	    (if (= (+ index 1) str-len) ; bad format string.
-		(tm:time-error 'tm:date-printer 'bad-date-format-string 
+		(tm:time-error 'tm:date-printer 'bad-date-format-string
 			       format-string)
                 (let ( (pad-char? (string-ref format-string (+ index 1))) )
                   (cond
                     ((char=? pad-char? #\-)
                      (if (= (+ index 2) str-len) ; bad format string.
-                         (tm:time-error 'tm:date-printer 'bad-date-format-string 
+                         (tm:time-error 'tm:date-printer 'bad-date-format-string
                                         format-string)
-                         (let ( (formatter (tm:get-formatter 
+                         (let ( (formatter (tm:get-formatter
                                             (string-ref format-string
                                                         (+ index 2)))) )
                            (if (not formatter)
-                               (tm:time-error 'tm:date-printer 'bad-date-format-string 
+                               (tm:time-error 'tm:date-printer 'bad-date-format-string
                                               format-string)
                                (begin
                                  (formatter date #f port)
                                  (tm:date-printer date (+ index 3)
                                                   format-string str-len port))))))
-                    
+
                     ((char=? pad-char? #\_)
                      (if (= (+ index 2) str-len) ; bad format string.
-                         (tm:time-error 'tm:date-printer 'bad-date-format-string 
+                         (tm:time-error 'tm:date-printer 'bad-date-format-string
                                         format-string)
-                         (let ( (formatter (tm:get-formatter 
+                         (let ( (formatter (tm:get-formatter
                                             (string-ref format-string
                                                         (+ index 2)))) )
                            (if (not formatter)
-                               (tm:time-error 'tm:date-printer 'bad-date-format-string 
+                               (tm:time-error 'tm:date-printer 'bad-date-format-string
                                               format-string)
                                (begin
                                  (formatter date #\space port)
                                  (tm:date-printer date (+ index 3)
                                                   format-string str-len port))))))
                     (else
-                     (let ( (formatter (tm:get-formatter 
+                     (let ( (formatter (tm:get-formatter
                                         (string-ref format-string
                                                     (+ index 1)))) )
                        (if (not formatter)
-                           (tm:time-error 'tm:date-printer 'bad-date-format-string 
+                           (tm:time-error 'tm:date-printer 'bad-date-format-string
                                           format-string)
                            (begin
                              (formatter date #\0 port)
@@ -1242,7 +1240,7 @@
 
 ;; read an fractional integer upto n characters long on port; upto -> #f if any length
 ;;
-;; The return value is normalized to upto decimal places. For example, if upto is 9 and 
+;; The return value is normalized to upto decimal places. For example, if upto is 9 and
 ;; the string read is "123", the return value is 123000000.
 (define (tm:fractional-integer-reader upto port)
   (define (accum-int port accum nchars)
@@ -1266,8 +1264,8 @@
       (let ((ch (peek-char port)))
 	(cond
           ((>= nchars n) accum)
-          ((eof-object? ch) 
-           (tm:time-error 'string->date 'bad-date-template-string 
+          ((eof-object? ch)
+           (tm:time-error 'string->date 'bad-date-template-string
                           "Premature ending to integer read."))
           ((char-numeric? ch)
            (set! padding-ok #f)
@@ -1278,7 +1276,7 @@
            (read-char port) ; consume padding
            (accum-int port accum (+ nchars 1)))
           (else ; padding where it shouldn't be
-           (tm:time-error 'string->date 'bad-date-template-string 
+           (tm:time-error 'string->date 'bad-date-template-string
 			  "Non-numeric characters in integer read.")))))
     (accum-int port 0 0)))
 
@@ -1287,8 +1285,8 @@
   (lambda (port)
     (tm:integer-reader-exact n port)))
 
-(define (tm:zone-reader port) 
-  (let ( (offset 0) 
+(define (tm:zone-reader port)
+  (let ( (offset 0)
 	 (positive? #f) )
     (let ( (ch (read-char port)) )
       (if (eof-object? ch)
@@ -1335,10 +1333,10 @@
     (define (read-char-string)
       (let ((ch (peek-char port)))
 	(if (char-alphabetic? ch)
-	    (begin (write-char (read-char port) string-port) 
+	    (begin (write-char (read-char port) string-port)
 		   (read-char-string))
 	    (get-output-string string-port))))
-    (let* ( (str (read-char-string)) 
+    (let* ( (str (read-char-string))
 	    (index (indexer str)) )
       (if index index (tm:time-error 'string->date
 				     'bad-date-template-string
@@ -1358,7 +1356,7 @@
 
 ;; A List of formatted read directives.
 ;; Each entry is a list.
-;; 1. the character directive; 
+;; 1. the character directive;
 ;; a procedure, which takes a character as input & returns
 ;; 2. #t as soon as a character on the input port is acceptable
 ;; for input,
@@ -1368,7 +1366,7 @@
 ;; object (here, always the date) and (probably) side-effects it.
 ;; In some cases (e.g., ~A) the action is to do nothing
 
-(define tm:read-directives 
+(define tm:read-directives
   (let ( (ireader4 (tm:make-integer-reader 4))
 	 (ireader2 (tm:make-integer-reader 2))
 	 (fireader9 (tm:make-fractional-integer-reader 9))
@@ -1386,7 +1384,7 @@
 	 (char-fail (lambda (ch) #t))
 	 (do-nothing (lambda (val object) (values)))
 	 )
-    
+
     (list
      (list #\~ char-fail (tm:make-char-id-reader #\~) do-nothing)
      (list #\a char-alphabetic? locale-reader-abbr-weekday do-nothing)
@@ -1418,7 +1416,7 @@
 					 (tm:set-date-nanosecond! object val)))
      (list #\S char-numeric? ireader2 (lambda (val object)
                                         (tm:set-date-second! object val)))
-     (list #\y char-fail eireader2 
+     (list #\y char-fail eireader2
            (lambda (val object)
              (tm:set-date-year! object (tm:natural-year val))))
      (list #\Y char-numeric? ireader4 (lambda (val object)
@@ -1440,7 +1438,7 @@
 	  (if (not (skipper ch))
 	      (begin (read-char port) (skip-until port skipper))))))
   (if (>= index str-len)
-      (begin 
+      (begin
 	(values))
       (let ( (current-char (string-ref format-string index)) )
 	(if (not (char=? current-char #\~))
@@ -1487,4 +1485,3 @@
     (if (tm:date-ok? newdate)
 	newdate
 	(tm:time-error 'string->date 'bad-date-format-string (list "Incomplete date read. " newdate template-string)))))
-

--- a/%3a19/time.sls
+++ b/%3a19/time.sls
@@ -155,6 +155,8 @@
 
   (define (tm:local-tz-offset) host:timezone-offset)
 
+  (define eof (eof-object))
+
   (let-syntax ((define (vanish-define define (tm:time-error-types
                                               tm:time-error
                                               tm:get-time-of-day


### PR DESCRIPTION
This updates SRFI-19 to the latest reference implementation from:

  https://github.com/scheme-requests-for-implementation/srfi-19/

It is based on revision 9a81ca80c5f19c0f246a5537a4fedbcfdf56cd10.

This also happens to fix the license, which was previously really
restrictive. Now it has the standard SRFI license: MIT/Expat.